### PR TITLE
Auto-create demo accounts on first login and document behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="file:./dev.db"
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="change-me"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env
+*.db
+*.log

--- a/README.md
+++ b/README.md
@@ -1,18 +1,62 @@
-# codex_test
+# MVP Conseils de classe & quorum
 
-Dépôt de test pour visualiser les processus de l'entreprise.
+Application interne (FR) pour suivre la présence des professeurs aux conseils de classe et garantir un quorum minimal de 70%.
 
-Une version interactive de la frise est disponible dans le fichier `index.html`.
+## Stack
+- Next.js + TypeScript + Tailwind
+- Prisma + SQLite
+- NextAuth (credentials)
+- Zod pour la validation
 
-## Frise chronologique des processus
+## Installation
+```bash
+npm install
+cp .env.example .env
+```
 
-| Étape | Qui ? | Action | Documents |
-|-------|-------|--------|-----------|
-| Phase commerciale et appels d'offres | Équipe commerciale | Répondre aux devis et appels d'offres, rédiger le mémoire technique, chiffrer le projet | Devis, CCAP, CCTP, mémoire technique |
-| Gestion de projet | Conducteur de travaux | Prendre en main l'affaire, relire les documents, établir le planning et les documents de suivi | CCAP, CCTP, mémoire technique, plans de sécurité |
-| Bureau d'étude | Bureau d'étude | Réaliser les calculs et le dimensionnement, produire les plans pour validation, fabrication et pose, constituer le DOE | CCTP, plans, notes de calcul, fiches techniques, certificats |
-| Production en atelier | Atelier | Fabriquer et assembler les ouvrages selon les plans | Dossier de plans |
-| Chantier et pose | Équipe chantier | Organiser le transport, poser les ouvrages, gérer le matériel | Planning, rapports de chantier |
-| Achats et approvisionnement | Service achats | Consulter les fournisseurs, passer les commandes, relancer pour les délais | Demandes d'offre, bons de commande, confirmations |
-| Comptabilité et paiements | Comptable | Assurer la comptabilité, gérer les paiements et les relances clients | Factures, relevés |
+## Commandes
+```bash
+npm run prisma:generate
+npm run prisma:migrate
+npm run prisma:seed
+npm run dev
+```
 
+## Comment visualiser l'application ?
+1. Démarrer le serveur de dev avec `npm run dev`.
+2. Ouvrir `http://localhost:3000`.
+3. Se connecter via `/login` avec les comptes de démonstration (ci-dessous).
+
+Tests :
+```bash
+npm run test
+```
+
+## Comptes de démonstration (seed)
+- Direction : `direction@gmail.com` / `direction`
+- Professeur : `professeur@gmail.com` / `professeur`
+> Astuce : si le seed n'a pas été exécuté, ces comptes sont créés automatiquement lors de la première connexion.
+
+## Endpoints principaux
+### Admin
+- `GET/POST /api/admin/teachers`
+- `PUT/DELETE /api/admin/teachers/:id`
+- `GET/POST /api/admin/classes`
+- `GET/PUT/DELETE /api/admin/classes/:id`
+- `POST/DELETE /api/admin/assignments`
+- `GET/POST /api/admin/councils`
+- `GET/PUT/DELETE /api/admin/councils/:id`
+- `GET /api/admin/export?type=councils|teachers`
+
+### Prof
+- `GET /api/me/councils`
+- `POST /api/me/attendance`
+
+## CSV import classes
+Le CSV doit contenir **une seule colonne** : le nom de la classe. L’import est disponible sur `/admin/classes`.
+
+## Prochaines étapes
+- Notifications email/SMS
+- Quotas avancés par professeur
+- Import CSV complet (profs/classes/assignations)
+- Exports enrichis (présences par conseil détaillées)

--- a/app/admin/classes/[classId]/page.tsx
+++ b/app/admin/classes/[classId]/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import PageHeader from "@/components/PageHeader";
+import Card from "@/components/Card";
+import Link from "next/link";
+
+interface TeacherOption {
+  id: string;
+  name: string;
+}
+
+interface ClassDetail {
+  id: string;
+  name: string;
+  teachers: { teacher: { id: string; teacherProfile?: { name: string | null } | null; email: string } }[];
+  councils: { id: string; startsAt: string; location?: string | null }[];
+}
+
+export default function ClassDetailPage() {
+  const params = useParams();
+  const classId = params.classId as string;
+  const [clazz, setClazz] = useState<ClassDetail | null>(null);
+  const [teachers, setTeachers] = useState<TeacherOption[]>([]);
+  const [name, setName] = useState("");
+  const [selectedTeacher, setSelectedTeacher] = useState("");
+
+  const loadData = async () => {
+    const [classResponse, teachersResponse] = await Promise.all([
+      fetch(`/api/admin/classes/${classId}`),
+      fetch("/api/admin/teachers")
+    ]);
+    const classData = await classResponse.json();
+    const teachersData = await teachersResponse.json();
+    setClazz(classData);
+    setName(classData.name);
+    setTeachers(teachersData);
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [classId]);
+
+  const handleRename = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await fetch(`/api/admin/classes/${classId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name })
+    });
+    loadData();
+  };
+
+  const handleAssign = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await fetch("/api/admin/assignments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ classId, teacherId: selectedTeacher })
+    });
+    setSelectedTeacher("");
+    loadData();
+  };
+
+  const handleRemove = async (teacherId: string) => {
+    await fetch("/api/admin/assignments", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ classId, teacherId })
+    });
+    loadData();
+  };
+
+  if (!clazz) {
+    return <p>Chargement...</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={`Classe ${clazz.name}`} subtitle="Mettre à jour le nom et les enseignants." />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card title="Renommer la classe">
+          <form onSubmit={handleRename} className="space-y-2">
+            <input
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+            />
+            <button className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white" type="submit">
+              Mettre à jour
+            </button>
+          </form>
+        </Card>
+        <Card title="Assigner un professeur">
+          <form onSubmit={handleAssign} className="space-y-2">
+            <select
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={selectedTeacher}
+              onChange={(event) => setSelectedTeacher(event.target.value)}
+              required
+            >
+              <option value="">Sélectionner un professeur</option>
+              {teachers.map((teacher) => (
+                <option key={teacher.id} value={teacher.id}>
+                  {teacher.name}
+                </option>
+              ))}
+            </select>
+            <button className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white" type="submit">
+              Assigner
+            </button>
+          </form>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card title="Professeurs assignés">
+          <ul className="space-y-2">
+            {clazz.teachers.map((link) => (
+              <li key={link.teacher.id} className="flex items-center justify-between">
+                <span>{link.teacher.teacherProfile?.name ?? link.teacher.email}</span>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(link.teacher.id)}
+                  className="text-xs font-semibold text-rose-600"
+                >
+                  Retirer
+                </button>
+              </li>
+            ))}
+          </ul>
+        </Card>
+        <Card title="Conseils de classe">
+          <ul className="space-y-2">
+            {clazz.councils.map((council) => (
+              <li key={council.id} className="flex items-center justify-between">
+                <span>
+                  {new Date(council.startsAt).toLocaleString("fr-FR")} · {council.location ?? ""}
+                </span>
+                <Link href={`/admin/councils/${council.id}`} className="text-xs font-semibold">
+                  Voir
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/classes/page.tsx
+++ b/app/admin/classes/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import PageHeader from "@/components/PageHeader";
+import Card from "@/components/Card";
+
+interface ClassRow {
+  id: string;
+  name: string;
+  teachers: { id: string; name: string }[];
+}
+
+export default function ClassesPage() {
+  const [classes, setClasses] = useState<ClassRow[]>([]);
+  const [name, setName] = useState("");
+  const [csvStatus, setCsvStatus] = useState<string | null>(null);
+
+  const loadClasses = () => {
+    fetch("/api/admin/classes")
+      .then((response) => response.json())
+      .then((data) => setClasses(data));
+  };
+
+  useEffect(() => {
+    loadClasses();
+  }, []);
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await fetch("/api/admin/classes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name })
+    });
+    setName("");
+    loadClasses();
+  };
+
+  const handleCsvImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const response = await fetch("/api/admin/classes", {
+      method: "POST",
+      headers: { "content-type": "text/csv" },
+      body: text
+    });
+    const data = await response.json();
+    setCsvStatus(`Import terminé : ${data.created ?? 0} classe(s) ajoutée(s).`);
+    loadClasses();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Classes" subtitle="Gérer les classes et assignations." />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card title="Ajouter une classe">
+          <form onSubmit={handleCreate} className="space-y-3">
+            <input
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              placeholder="Nom de la classe"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+            />
+            <button className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white" type="submit">
+              Ajouter
+            </button>
+          </form>
+        </Card>
+        <Card title="Importer un CSV">
+          <div className="space-y-2">
+            <p>Fichier CSV avec une seule colonne : nom de la classe.</p>
+            <input type="file" accept=".csv" onChange={handleCsvImport} />
+            {csvStatus ? <p className="text-xs text-slate-500">{csvStatus}</p> : null}
+          </div>
+        </Card>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <div className="border-b border-slate-100 px-4 py-3 text-sm font-semibold text-slate-700">Liste des classes</div>
+        <div className="divide-y divide-slate-100">
+          {classes.map((clazz) => (
+            <div key={clazz.id} className="flex flex-col gap-2 px-4 py-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">{clazz.name}</p>
+                <p className="text-xs text-slate-500">
+                  {clazz.teachers.length} professeur(s) assigné(s)
+                </p>
+              </div>
+              <Link href={`/admin/classes/${clazz.id}`} className="text-sm font-semibold text-slate-900">
+                Détails & assignations
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/councils/[councilId]/page.tsx
+++ b/app/admin/councils/[councilId]/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import PageHeader from "@/components/PageHeader";
+import Card from "@/components/Card";
+import StatusBadge from "@/components/StatusBadge";
+
+interface CouncilDetail {
+  id: string;
+  classId: string;
+  startsAt: string;
+  location?: string | null;
+  class: {
+    name: string;
+    teachers: { teacher: { id: string; email: string; teacherProfile?: { name: string | null } | null } }[];
+  };
+  attendances: { teacherId: string; status: string }[];
+  quorumRequired: number;
+  quorumOk: boolean;
+  present: number;
+  expected: number;
+}
+
+interface ClassRow {
+  id: string;
+  name: string;
+}
+
+export default function CouncilDetailPage() {
+  const params = useParams();
+  const councilId = params.councilId as string;
+  const [council, setCouncil] = useState<CouncilDetail | null>(null);
+  const [classes, setClasses] = useState<ClassRow[]>([]);
+  const [classId, setClassId] = useState("");
+  const [startsAt, setStartsAt] = useState("");
+  const [location, setLocation] = useState("");
+
+  const loadData = async () => {
+    const [councilResponse, classesResponse] = await Promise.all([
+      fetch(`/api/admin/councils/${councilId}`),
+      fetch("/api/admin/classes")
+    ]);
+    const councilData = await councilResponse.json();
+    setCouncil(councilData);
+    setClasses(await classesResponse.json());
+    setClassId(councilData.classId);
+    setStartsAt(new Date(councilData.startsAt).toISOString().slice(0, 16));
+    setLocation(councilData.location ?? "");
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [councilId]);
+
+  const handleUpdate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await fetch(`/api/admin/councils/${councilId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ classId, startsAt, location })
+    });
+    loadData();
+  };
+
+  if (!council) {
+    return <p>Chargement...</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={`Conseil ${council.class.name}`} subtitle="Mettre à jour les informations." />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card title="Résumé du quorum">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-slate-500">Présents confirmés</p>
+              <p className="text-2xl font-semibold">
+                {council.present}/{council.expected}
+              </p>
+              <p className="text-xs text-slate-500">Quorum requis : {council.quorumRequired}</p>
+            </div>
+            <StatusBadge label={council.quorumOk ? "OK" : "RISQUE"} tone={council.quorumOk ? "green" : "red"} />
+          </div>
+        </Card>
+        <Card title="Mettre à jour le conseil">
+          <form onSubmit={handleUpdate} className="space-y-2">
+            <select
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={classId}
+              onChange={(event) => setClassId(event.target.value)}
+            >
+              {classes.map((clazz) => (
+                <option key={clazz.id} value={clazz.id}>
+                  {clazz.name}
+                </option>
+              ))}
+            </select>
+            <input
+              type="datetime-local"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={startsAt}
+              onChange={(event) => setStartsAt(event.target.value)}
+              required
+            />
+            <input
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={location}
+              onChange={(event) => setLocation(event.target.value)}
+              placeholder="Salle"
+            />
+            <button className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white" type="submit">
+              Enregistrer
+            </button>
+          </form>
+        </Card>
+      </div>
+
+      <Card title="Réponses des professeurs">
+        <ul className="space-y-2">
+          {council.class.teachers.map((link) => {
+            const attendance = council.attendances.find((item) => item.teacherId === link.teacher.id);
+            const status = attendance?.status ?? "PENDING";
+            const badgeTone = status === "PRESENT" ? "green" : status === "ABSENT" ? "red" : "amber";
+            const label = status === "PRESENT" ? "Présent" : status === "ABSENT" ? "Indisponible" : "En attente";
+            return (
+              <li key={link.teacher.id} className="flex items-center justify-between">
+                <span>{link.teacher.teacherProfile?.name ?? link.teacher.email}</span>
+                <StatusBadge label={label} tone={badgeTone} />
+              </li>
+            );
+          })}
+        </ul>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/councils/page.tsx
+++ b/app/admin/councils/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import PageHeader from "@/components/PageHeader";
+import Card from "@/components/Card";
+import StatusBadge from "@/components/StatusBadge";
+
+interface CouncilRow {
+  id: string;
+  classId: string;
+  className: string;
+  startsAt: string;
+  location?: string | null;
+  expected: number;
+  present: number;
+  quorumRequired: number;
+  quorumOk: boolean;
+}
+
+interface ClassRow {
+  id: string;
+  name: string;
+}
+
+export default function CouncilsPage() {
+  const [councils, setCouncils] = useState<CouncilRow[]>([]);
+  const [classes, setClasses] = useState<ClassRow[]>([]);
+  const [classId, setClassId] = useState("");
+  const [startsAt, setStartsAt] = useState("");
+  const [location, setLocation] = useState("");
+
+  const loadData = async () => {
+    const [councilResponse, classesResponse] = await Promise.all([
+      fetch("/api/admin/councils"),
+      fetch("/api/admin/classes")
+    ]);
+    setCouncils(await councilResponse.json());
+    setClasses(await classesResponse.json());
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await fetch("/api/admin/councils", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ classId, startsAt, location })
+    });
+    setClassId("");
+    setStartsAt("");
+    setLocation("");
+    loadData();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Conseils de classe" subtitle="Créer et suivre les conseils." />
+
+      <Card title="Créer un conseil">
+        <form onSubmit={handleCreate} className="grid gap-3 md:grid-cols-3">
+          <select
+            className="rounded-lg border border-slate-200 px-3 py-2"
+            value={classId}
+            onChange={(event) => setClassId(event.target.value)}
+            required
+          >
+            <option value="">Classe</option>
+            {classes.map((clazz) => (
+              <option key={clazz.id} value={clazz.id}>
+                {clazz.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="datetime-local"
+            className="rounded-lg border border-slate-200 px-3 py-2"
+            value={startsAt}
+            onChange={(event) => setStartsAt(event.target.value)}
+            required
+          />
+          <input
+            className="rounded-lg border border-slate-200 px-3 py-2"
+            placeholder="Lieu"
+            value={location}
+            onChange={(event) => setLocation(event.target.value)}
+          />
+          <div>
+            <button className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white" type="submit">
+              Ajouter
+            </button>
+          </div>
+        </form>
+      </Card>
+
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <div className="border-b border-slate-100 px-4 py-3 text-sm font-semibold text-slate-700">Liste des conseils</div>
+        <div className="divide-y divide-slate-100">
+          {councils.map((council) => (
+            <div key={council.id} className="flex flex-col gap-2 px-4 py-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">
+                  {council.className} · {new Date(council.startsAt).toLocaleString("fr-FR")}
+                </p>
+                <p className="text-xs text-slate-500">Lieu : {council.location ?? "Non précisé"}</p>
+                <p className="text-xs text-slate-500">
+                  Présents {council.present}/{council.expected} · quorum {council.quorumRequired}
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <StatusBadge label={council.quorumOk ? "OK" : "RISQUE"} tone={council.quorumOk ? "green" : "amber"} />
+                <Link href={`/admin/councils/${council.id}`} className="text-sm font-semibold">
+                  Détails
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PageHeader from "@/components/PageHeader";
+import StatusBadge from "@/components/StatusBadge";
+import Card from "@/components/Card";
+import Link from "next/link";
+
+interface CouncilRow {
+  id: string;
+  className: string;
+  startsAt: string;
+  location?: string | null;
+  expected: number;
+  present: number;
+  quorumRequired: number;
+  quorumOk: boolean;
+}
+
+export default function AdminDashboardPage() {
+  const [councils, setCouncils] = useState<CouncilRow[]>([]);
+
+  useEffect(() => {
+    fetch("/api/admin/councils")
+      .then((response) => response.json())
+      .then((data) => setCouncils(data));
+  }, []);
+
+  const upcoming = councils.filter((council) => new Date(council.startsAt) >= new Date());
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Dashboard"
+        subtitle="Suivi des conseils à venir et du quorum minimal."
+        actions={
+          <Link
+            href="/admin/councils"
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+          >
+            Gérer les conseils
+          </Link>
+        }
+      />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card title="Conseils à venir">
+          <p className="text-3xl font-semibold text-slate-900">{upcoming.length}</p>
+          <p className="text-sm text-slate-500">Conseils programmés</p>
+        </Card>
+        <Card title="Risque de quorum">
+          <p className="text-3xl font-semibold text-slate-900">
+            {upcoming.filter((council) => !council.quorumOk).length}
+          </p>
+          <p className="text-sm text-slate-500">Conseils sous le seuil de 70%</p>
+        </Card>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <div className="border-b border-slate-100 px-4 py-3 text-sm font-semibold text-slate-700">
+          Conseils à venir
+        </div>
+        <div className="divide-y divide-slate-100">
+          {upcoming.map((council) => (
+            <div key={council.id} className="flex flex-col gap-2 px-4 py-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">
+                  {council.className} · {new Date(council.startsAt).toLocaleString("fr-FR")}
+                </p>
+                <p className="text-xs text-slate-500">Lieu : {council.location ?? "Non précisé"}</p>
+                <p className="text-xs text-slate-500">
+                  Présents {council.present}/{council.expected} (quorum requis {council.quorumRequired})
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <StatusBadge label={council.quorumOk ? "OK" : "RISQUE"} tone={council.quorumOk ? "green" : "red"} />
+                <Link
+                  href={`/admin/councils/${council.id}`}
+                  className="text-sm font-semibold text-slate-900"
+                >
+                  Détail
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/teachers/page.tsx
+++ b/app/admin/teachers/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PageHeader from "@/components/PageHeader";
+import Card from "@/components/Card";
+
+interface TeacherRow {
+  id: string;
+  email: string;
+  name: string;
+  subjects?: string;
+}
+
+export default function TeachersPage() {
+  const [teachers, setTeachers] = useState<TeacherRow[]>([]);
+  const [form, setForm] = useState({ email: "", name: "", subjects: "" });
+
+  const loadTeachers = () => {
+    fetch("/api/admin/teachers")
+      .then((response) => response.json())
+      .then((data) => setTeachers(data));
+  };
+
+  useEffect(() => {
+    loadTeachers();
+  }, []);
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await fetch("/api/admin/teachers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(form)
+    });
+    setForm({ email: "", name: "", subjects: "" });
+    loadTeachers();
+  };
+
+  const handleUpdate = async (teacher: TeacherRow) => {
+    await fetch(`/api/admin/teachers/${teacher.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(teacher)
+    });
+    loadTeachers();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Professeurs" subtitle="Créer et mettre à jour les informations." />
+
+      <Card title="Ajouter un professeur">
+        <form onSubmit={handleCreate} className="grid gap-3 md:grid-cols-3">
+          <input
+            className="rounded-lg border border-slate-200 px-3 py-2"
+            placeholder="Nom"
+            value={form.name}
+            onChange={(event) => setForm({ ...form, name: event.target.value })}
+            required
+          />
+          <input
+            className="rounded-lg border border-slate-200 px-3 py-2"
+            placeholder="Email"
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm({ ...form, email: event.target.value })}
+            required
+          />
+          <input
+            className="rounded-lg border border-slate-200 px-3 py-2"
+            placeholder="Matières"
+            value={form.subjects}
+            onChange={(event) => setForm({ ...form, subjects: event.target.value })}
+          />
+          <div>
+            <button className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white" type="submit">
+              Ajouter
+            </button>
+          </div>
+        </form>
+        <p className="text-xs text-slate-500">Mot de passe par défaut : professeur</p>
+      </Card>
+
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <div className="border-b border-slate-100 px-4 py-3 text-sm font-semibold text-slate-700">
+          Liste des professeurs
+        </div>
+        <div className="divide-y divide-slate-100">
+          {teachers.map((teacher) => (
+            <div key={teacher.id} className="flex flex-col gap-2 px-4 py-3 md:flex-row md:items-center md:justify-between">
+              <div className="grid gap-2 md:grid-cols-3">
+                <input
+                  className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
+                  value={teacher.name}
+                  onChange={(event) => {
+                    const next = teachers.map((item) =>
+                      item.id === teacher.id ? { ...item, name: event.target.value } : item
+                    );
+                    setTeachers(next);
+                  }}
+                />
+                <input
+                  className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
+                  value={teacher.email}
+                  onChange={(event) => {
+                    const next = teachers.map((item) =>
+                      item.id === teacher.id ? { ...item, email: event.target.value } : item
+                    );
+                    setTeachers(next);
+                  }}
+                />
+                <input
+                  className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
+                  value={teacher.subjects ?? ""}
+                  onChange={(event) => {
+                    const next = teachers.map((item) =>
+                      item.id === teacher.id ? { ...item, subjects: event.target.value } : item
+                    );
+                    setTeachers(next);
+                  }}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => handleUpdate(teacher)}
+                className="text-sm font-semibold text-slate-900"
+              >
+                Mettre à jour
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -1,0 +1,67 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { assignmentSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = assignmentSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const link = await prisma.$transaction(async (tx) => {
+    const created = await tx.classTeacher.create({
+      data: {
+        classId: parsed.data.classId,
+        teacherId: parsed.data.teacherId
+      }
+    });
+
+    const councils = await tx.council.findMany({ where: { classId: parsed.data.classId } });
+    if (councils.length > 0) {
+      await tx.attendance.createMany({
+        data: councils.map((council) => ({
+          councilId: council.id,
+          teacherId: parsed.data.teacherId,
+          status: "PENDING"
+        })),
+        skipDuplicates: true
+      });
+    }
+
+    return created;
+  });
+
+  return jsonOk(link, 201);
+}
+
+export async function DELETE(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = assignmentSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  await prisma.classTeacher.delete({
+    where: {
+      classId_teacherId: {
+        classId: parsed.data.classId,
+        teacherId: parsed.data.teacherId
+      }
+    }
+  });
+
+  return jsonOk({ success: true });
+}

--- a/app/api/admin/classes/[classId]/route.ts
+++ b/app/api/admin/classes/[classId]/route.ts
@@ -1,0 +1,63 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { classSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+
+interface Params {
+  params: { classId: string };
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const clazz = await prisma.class.findUnique({
+    where: { id: params.classId },
+    include: {
+      teachers: { include: { teacher: { include: { teacherProfile: true } } } },
+      councils: { orderBy: { startsAt: "asc" } }
+    }
+  });
+
+  if (!clazz) {
+    return jsonError("Not found", 404);
+  }
+
+  return jsonOk(clazz);
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = classSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const clazz = await prisma.class.update({
+    where: { id: params.classId },
+    data: { name: parsed.data.name }
+  });
+
+  return jsonOk(clazz);
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  await prisma.class.delete({
+    where: { id: params.classId }
+  });
+
+  return jsonOk({ success: true });
+}

--- a/app/api/admin/classes/route.ts
+++ b/app/api/admin/classes/route.ts
@@ -1,0 +1,77 @@
+import { getServerSession } from "next-auth";
+import { parse } from "csv-parse/sync";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { classSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const classes = await prisma.class.findMany({
+    include: {
+      teachers: { include: { teacher: { include: { teacherProfile: true } } } }
+    },
+    orderBy: { name: "asc" }
+  });
+
+  return jsonOk(
+    classes.map((clazz) => ({
+      id: clazz.id,
+      name: clazz.name,
+      teachers: clazz.teachers.map((link) => ({
+        id: link.teacher.id,
+        name: link.teacher.teacherProfile?.name ?? link.teacher.email
+      }))
+    }))
+  );
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+
+  if (contentType.includes("text/csv")) {
+    const text = await request.text();
+    const records = parse(text, {
+      trim: true,
+      skip_empty_lines: true
+    }) as string[][];
+
+    const classNames = records
+      .map((row) => row[0])
+      .filter((name) => typeof name === "string" && name.length > 1);
+
+    if (classNames.length === 0) {
+      return jsonError("CSV vide", 422);
+    }
+
+    const created = await prisma.class.createMany({
+      data: classNames.map((name) => ({ name })),
+      skipDuplicates: true
+    });
+
+    return jsonOk({ created: created.count }, 201);
+  }
+
+  const body = await request.json();
+  const parsed = classSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const clazz = await prisma.class.create({
+    data: {
+      name: parsed.data.name
+    }
+  });
+
+  return jsonOk(clazz, 201);
+}

--- a/app/api/admin/councils/[councilId]/route.ts
+++ b/app/api/admin/councils/[councilId]/route.ts
@@ -1,0 +1,78 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { councilSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+import { quorumStatus } from "@/lib/quorum";
+
+interface Params {
+  params: { councilId: string };
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const council = await prisma.council.findUnique({
+    where: { id: params.councilId },
+    include: {
+      class: { include: { teachers: { include: { teacher: { include: { teacherProfile: true } } } } } },
+      attendances: true
+    }
+  });
+
+  if (!council) {
+    return jsonError("Not found", 404);
+  }
+
+  const expected = council.class.teachers.length;
+  const present = council.attendances.filter((attendance) => attendance.status === "PRESENT").length;
+  const status = quorumStatus(present, expected);
+
+  return jsonOk({
+    ...council,
+    expected,
+    present,
+    quorumRequired: status.required,
+    quorumOk: status.ok
+  });
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = councilSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const council = await prisma.council.update({
+    where: { id: params.councilId },
+    data: {
+      classId: parsed.data.classId,
+      startsAt: new Date(parsed.data.startsAt),
+      location: parsed.data.location
+    }
+  });
+
+  return jsonOk(council);
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  await prisma.council.delete({
+    where: { id: params.councilId }
+  });
+
+  return jsonOk({ success: true });
+}

--- a/app/api/admin/councils/route.ts
+++ b/app/api/admin/councils/route.ts
@@ -1,0 +1,84 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { councilSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+import { quorumStatus } from "@/lib/quorum";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const councils = await prisma.council.findMany({
+    include: {
+      class: {
+        include: { teachers: true }
+      },
+      attendances: true
+    },
+    orderBy: { startsAt: "asc" }
+  });
+
+  return jsonOk(
+    councils.map((council) => {
+      const expected = council.class.teachers.length;
+      const present = council.attendances.filter((attendance) => attendance.status === "PRESENT").length;
+      const status = quorumStatus(present, expected);
+      return {
+        id: council.id,
+        classId: council.classId,
+        className: council.class.name,
+        startsAt: council.startsAt,
+        location: council.location,
+        expected,
+        present,
+        quorumRequired: status.required,
+        quorumOk: status.ok
+      };
+    })
+  );
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = councilSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const council = await prisma.$transaction(async (tx) => {
+    const created = await tx.council.create({
+      data: {
+        classId: parsed.data.classId,
+        startsAt: new Date(parsed.data.startsAt),
+        location: parsed.data.location
+      }
+    });
+
+    const classTeachers = await tx.classTeacher.findMany({
+      where: { classId: parsed.data.classId }
+    });
+
+    if (classTeachers.length > 0) {
+      await tx.attendance.createMany({
+        data: classTeachers.map((link) => ({
+          councilId: created.id,
+          teacherId: link.teacherId,
+          status: "PENDING"
+        })),
+        skipDuplicates: true
+      });
+    }
+
+    return created;
+  });
+
+  return jsonOk(council, 201);
+}

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -1,0 +1,66 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get("type") ?? "councils";
+
+  if (type === "teachers") {
+    const teachers = await prisma.user.findMany({
+      where: { role: "PROF" },
+      include: {
+        teacherProfile: true,
+        attendances: true
+      }
+    });
+
+    const rows = ["teacher,email,present_count,absent_count,pending_count"];
+    for (const teacher of teachers) {
+      const present = teacher.attendances.filter((attendance) => attendance.status === "PRESENT").length;
+      const absent = teacher.attendances.filter((attendance) => attendance.status === "ABSENT").length;
+      const pending = teacher.attendances.filter((attendance) => attendance.status === "PENDING").length;
+      rows.push(
+        `${teacher.teacherProfile?.name ?? teacher.email},${teacher.email},${present},${absent},${pending}`
+      );
+    }
+
+    return new NextResponse(rows.join("\n"), {
+      status: 200,
+      headers: {
+        "content-type": "text/csv"
+      }
+    });
+  }
+
+  const councils = await prisma.council.findMany({
+    include: {
+      class: true,
+      attendances: true
+    },
+    orderBy: { startsAt: "asc" }
+  });
+
+  const rows = ["class,starts_at,location,present_count,absent_count,pending_count"];
+  for (const council of councils) {
+    const present = council.attendances.filter((attendance) => attendance.status === "PRESENT").length;
+    const absent = council.attendances.filter((attendance) => attendance.status === "ABSENT").length;
+    const pending = council.attendances.filter((attendance) => attendance.status === "PENDING").length;
+    rows.push(
+      `${council.class.name},${council.startsAt.toISOString()},${council.location ?? ""},${present},${absent},${pending}`
+    );
+  }
+
+  return new NextResponse(rows.join("\n"), {
+    status: 200,
+    headers: {
+      "content-type": "text/csv"
+    }
+  });
+}

--- a/app/api/admin/teachers/[teacherId]/route.ts
+++ b/app/api/admin/teachers/[teacherId]/route.ts
@@ -1,0 +1,62 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { teacherSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+
+interface Params {
+  params: { teacherId: string };
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = teacherSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const teacher = await prisma.user.update({
+    where: { id: params.teacherId },
+    data: {
+      email: parsed.data.email,
+      teacherProfile: {
+        upsert: {
+          create: {
+            name: parsed.data.name,
+            subjects: parsed.data.subjects
+          },
+          update: {
+            name: parsed.data.name,
+            subjects: parsed.data.subjects
+          }
+        }
+      }
+    },
+    include: { teacherProfile: true }
+  });
+
+  return jsonOk({
+    id: teacher.id,
+    email: teacher.email,
+    name: teacher.teacherProfile?.name ?? "",
+    subjects: teacher.teacherProfile?.subjects ?? ""
+  });
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  await prisma.user.delete({
+    where: { id: params.teacherId }
+  });
+
+  return jsonOk({ success: true });
+}

--- a/app/api/admin/teachers/route.ts
+++ b/app/api/admin/teachers/route.ts
@@ -1,0 +1,68 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { teacherSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+import { hash } from "bcryptjs";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const teachers = await prisma.user.findMany({
+    where: { role: "PROF" },
+    include: { teacherProfile: true },
+    orderBy: { createdAt: "desc" }
+  });
+
+  return jsonOk(
+    teachers.map((teacher) => ({
+      id: teacher.id,
+      email: teacher.email,
+      name: teacher.teacherProfile?.name ?? "",
+      subjects: teacher.teacherProfile?.subjects ?? ""
+    }))
+  );
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("ADMIN", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = teacherSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const passwordHash = await hash("professeur", 10);
+
+  const teacher = await prisma.user.create({
+    data: {
+      email: parsed.data.email,
+      passwordHash,
+      role: "PROF",
+      teacherProfile: {
+        create: {
+          name: parsed.data.name,
+          subjects: parsed.data.subjects
+        }
+      }
+    },
+    include: { teacherProfile: true }
+  });
+
+  return jsonOk(
+    {
+      id: teacher.id,
+      email: teacher.email,
+      name: teacher.teacherProfile?.name ?? "",
+      subjects: teacher.teacherProfile?.subjects ?? ""
+    },
+    201
+  );
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/api/me/attendance/route.ts
+++ b/app/api/me/attendance/route.ts
@@ -1,0 +1,47 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { attendanceSchema } from "@/lib/validators";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+import { updateAttendance } from "@/lib/attendance-service";
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("PROF", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const body = await request.json();
+  const parsed = attendanceSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Invalid payload", 422);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session?.user?.email ?? "" }
+  });
+
+  if (!user) {
+    return jsonError("User not found", 404);
+  }
+
+  let attendance;
+  try {
+    attendance = await updateAttendance(prisma, {
+      councilId: parsed.data.councilId,
+      teacherId: user.id,
+      status: parsed.data.status
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    if (message === "Council not found") {
+      return jsonError(message, 404);
+    }
+    if (message === "Council read-only") {
+      return jsonError(message, 409);
+    }
+    return jsonError(message, 400);
+  }
+
+  return jsonOk(attendance);
+}

--- a/app/api/me/councils/route.ts
+++ b/app/api/me/councils/route.ts
@@ -1,0 +1,56 @@
+import { getServerSession } from "next-auth";
+import { authOptions, requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { jsonError, jsonOk } from "@/lib/api-utils";
+import { quorumStatus } from "@/lib/quorum";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!requireRole("PROF", session?.user?.role)) {
+    return jsonError("Unauthorized", 401);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session?.user?.email ?? "" }
+  });
+
+  if (!user) {
+    return jsonError("User not found", 404);
+  }
+
+  const councils = await prisma.council.findMany({
+    where: {
+      class: {
+        teachers: {
+          some: { teacherId: user.id }
+        }
+      }
+    },
+    include: {
+      class: { include: { teachers: true } },
+      attendances: true
+    },
+    orderBy: { startsAt: "asc" }
+  });
+
+  return jsonOk(
+    councils.map((council) => {
+      const expected = council.class.teachers.length;
+      const present = council.attendances.filter((attendance) => attendance.status === "PRESENT").length;
+      const status = quorumStatus(present, expected);
+      const myAttendance = council.attendances.find((attendance) => attendance.teacherId === user.id);
+
+      return {
+        id: council.id,
+        className: council.class.name,
+        startsAt: council.startsAt,
+        location: council.location,
+        myStatus: myAttendance?.status ?? "PENDING",
+        expected,
+        present,
+        quorumRequired: status.required,
+        quorumOk: status.ok
+      };
+    })
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import Providers from "./providers";
+
+export const metadata: Metadata = {
+  title: "Conseils de classe - Quorum",
+  description: "MVP interne pour gérer la présence des professeurs aux conseils de classe."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="fr">
+      <body className="min-h-screen">
+        <Providers>
+          <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-6">
+            {children}
+          </div>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import Card from "@/components/Card";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const result = await signIn("credentials", {
+      email,
+      password,
+      redirect: false
+    });
+
+    if (result?.error) {
+      setError("Identifiants invalides.");
+      setLoading(false);
+      return;
+    }
+
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-1 items-center">
+      <Card title="Connexion">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm font-semibold" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold" htmlFor="password">
+              Mot de passe
+            </label>
+            <input
+              id="password"
+              type="password"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </div>
+          {error ? <p className="text-sm text-rose-600">{error}</p> : null}
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+            disabled={loading}
+          >
+            {loading ? "Connexion..." : "Se connecter"}
+          </button>
+          <div className="text-xs text-slate-500">
+            <p>Direction : direction@gmail.com / direction</p>
+            <p>Professeur : professeur@gmail.com / professeur</p>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/app/me/councils/page.tsx
+++ b/app/me/councils/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PageHeader from "@/components/PageHeader";
+import StatusBadge from "@/components/StatusBadge";
+
+interface CouncilRow {
+  id: string;
+  className: string;
+  startsAt: string;
+  location?: string | null;
+  myStatus: string;
+  expected: number;
+  present: number;
+  quorumRequired: number;
+  quorumOk: boolean;
+}
+
+export default function MyCouncilsPage() {
+  const [councils, setCouncils] = useState<CouncilRow[]>([]);
+
+  const loadCouncils = () => {
+    fetch("/api/me/councils")
+      .then((response) => response.json())
+      .then((data) => setCouncils(data));
+  };
+
+  useEffect(() => {
+    loadCouncils();
+  }, []);
+
+  const updateAttendance = async (councilId: string, status: "PRESENT" | "ABSENT") => {
+    await fetch("/api/me/attendance", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ councilId, status })
+    });
+    loadCouncils();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Mes conseils" subtitle="Confirmez votre présence." />
+
+      <div className="space-y-4">
+        {councils.map((council) => {
+          const badgeTone = council.myStatus === "PRESENT" ? "green" : council.myStatus === "ABSENT" ? "red" : "amber";
+          const badgeLabel = council.myStatus === "PRESENT" ? "Présent" : council.myStatus === "ABSENT" ? "Indisponible" : "En attente";
+          return (
+            <div key={council.id} className="rounded-xl border border-slate-200 bg-white p-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">
+                    {council.className} · {new Date(council.startsAt).toLocaleString("fr-FR")}
+                  </p>
+                  <p className="text-xs text-slate-500">Lieu : {council.location ?? "Non précisé"}</p>
+                  <p className="text-xs text-slate-500">
+                    Quorum {council.present}/{council.expected} (requis {council.quorumRequired})
+                  </p>
+                </div>
+                <StatusBadge label={badgeLabel} tone={badgeTone} />
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => updateAttendance(council.id, "PRESENT")}
+                  className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white"
+                >
+                  Présent
+                </button>
+                <button
+                  type="button"
+                  onClick={() => updateAttendance(council.id, "ABSENT")}
+                  className="rounded-lg bg-rose-600 px-3 py-2 text-xs font-semibold text-white"
+                >
+                  Indisponible
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { signOut, useSession } from "next-auth/react";
+import Card from "@/components/Card";
+
+export default function HomePage() {
+  const { data: session } = useSession();
+  const role = session?.user?.role;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold">Conseils de classe</h1>
+        <p className="text-slate-600">
+          Suivi des présences et quorum minimal pour chaque conseil de classe.
+        </p>
+      </header>
+
+      {!session ? (
+        <Card title="Connexion">
+          <p>Veuillez vous connecter pour accéder à votre espace.</p>
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-white"
+          >
+            Se connecter
+          </Link>
+        </Card>
+      ) : (
+        <Card title={`Bienvenue ${session.user?.name ?? ""}`}>
+          <p>Vous êtes connecté en tant que {role === "ADMIN" ? "direction" : "professeur"}.</p>
+          <div className="flex flex-wrap gap-2">
+            {role === "ADMIN" ? (
+              <Link
+                href="/admin/dashboard"
+                className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+              >
+                Aller au dashboard
+              </Link>
+            ) : (
+              <Link
+                href="/me/councils"
+                className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+              >
+                Voir mes conseils
+              </Link>
+            )}
+            <button
+              type="button"
+              onClick={() => signOut({ callbackUrl: "/login" })}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold"
+            >
+              Se déconnecter
+            </button>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,15 @@
+interface CardProps {
+  title?: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export default function Card({ title, children, footer }: CardProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      {title ? <h2 className="text-lg font-semibold text-slate-900">{title}</h2> : null}
+      <div className="mt-3 space-y-3 text-sm text-slate-700">{children}</div>
+      {footer ? <div className="mt-4 border-t border-slate-100 pt-3 text-sm">{footer}</div> : null}
+    </div>
+  );
+}

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+}
+
+export default function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 border-b border-slate-200 pb-4 md:flex-row md:items-center md:justify-between">
+      <div>
+        <div className="flex items-center gap-3">
+          <Link href="/" className="text-sm font-semibold text-slate-500">
+            Quorum
+          </Link>
+          <span className="text-slate-300">/</span>
+          <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        </div>
+        {subtitle ? <p className="mt-1 text-sm text-slate-600">{subtitle}</p> : null}
+      </div>
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -1,0 +1,19 @@
+interface StatusBadgeProps {
+  label: string;
+  tone?: "green" | "amber" | "red" | "slate";
+}
+
+const toneClasses: Record<NonNullable<StatusBadgeProps["tone"]>, string> = {
+  green: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  amber: "bg-amber-50 text-amber-700 border-amber-200",
+  red: "bg-rose-50 text-rose-700 border-rose-200",
+  slate: "bg-slate-100 text-slate-700 border-slate-200"
+};
+
+export default function StatusBadge({ label, tone = "slate" }: StatusBadgeProps) {
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold ${toneClasses[tone]}`}>
+      {label}
+    </span>
+  );
+}

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export function jsonOk(data: unknown, status = 200) {
+  return NextResponse.json(data, { status });
+}
+
+export function jsonError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}

--- a/lib/attendance-service.ts
+++ b/lib/attendance-service.ts
@@ -1,0 +1,42 @@
+import { PrismaClient, AttendanceStatus } from "@prisma/client";
+
+interface UpdateAttendanceInput {
+  councilId: string;
+  teacherId: string;
+  status: AttendanceStatus;
+  now?: Date;
+}
+
+export async function updateAttendance(
+  prisma: PrismaClient,
+  { councilId, teacherId, status, now = new Date() }: UpdateAttendanceInput
+) {
+  const council = await prisma.council.findUnique({
+    where: { id: councilId }
+  });
+
+  if (!council) {
+    throw new Error("Council not found");
+  }
+
+  if (council.startsAt < now) {
+    throw new Error("Council read-only");
+  }
+
+  return prisma.attendance.upsert({
+    where: {
+      councilId_teacherId: {
+        councilId,
+        teacherId
+      }
+    },
+    update: {
+      status
+    },
+    create: {
+      councilId,
+      teacherId,
+      status
+    }
+  });
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,114 @@
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { compare, hash } from "bcryptjs";
+import { prisma } from "./prisma";
+
+export const authOptions: NextAuthOptions = {
+  session: {
+    strategy: "jwt"
+  },
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) {
+          return null;
+        }
+
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email },
+          include: { teacherProfile: true }
+        });
+
+        if (!user) {
+          const demoAccount = getDemoAccount(credentials.email);
+          if (!demoAccount || demoAccount.password !== credentials.password) {
+            return null;
+          }
+
+          const passwordHash = await hash(demoAccount.password, 10);
+          const createdUser = await prisma.user.create({
+            data: {
+              email: demoAccount.email,
+              passwordHash,
+              role: demoAccount.role,
+              teacherProfile: {
+                create: {
+                  name: demoAccount.name
+                }
+              }
+            },
+            include: { teacherProfile: true }
+          });
+
+          return {
+            id: createdUser.id,
+            name: createdUser.teacherProfile?.name ?? createdUser.email,
+            email: createdUser.email,
+            role: createdUser.role
+          };
+        }
+
+        const passwordValid = await compare(credentials.password, user.passwordHash);
+        if (!passwordValid) {
+          return null;
+        }
+
+        return {
+          id: user.id,
+          name: user.teacherProfile?.name ?? user.email,
+          email: user.email,
+          role: user.role
+        };
+      }
+    })
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as { role: string }).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.role = token.role as string;
+      }
+      return session;
+    }
+  },
+  pages: {
+    signIn: "/login"
+  }
+};
+
+export function requireRole(role: "ADMIN" | "PROF", sessionRole?: string | null) {
+  if (!sessionRole || sessionRole !== role) {
+    return false;
+  }
+  return true;
+}
+
+function getDemoAccount(email: string) {
+  if (email === "direction@gmail.com") {
+    return {
+      email,
+      password: "direction",
+      role: "ADMIN" as const,
+      name: "Direction"
+    };
+  }
+  if (email === "professeur@gmail.com") {
+    return {
+      email,
+      password: "professeur",
+      role: "PROF" as const,
+      name: "Professeur 1"
+    };
+  }
+  return null;
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ["error", "warn"]
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/lib/quorum.ts
+++ b/lib/quorum.ts
@@ -1,0 +1,14 @@
+export function requiredQuorum(totalTeachers: number): number {
+  if (totalTeachers <= 0) {
+    return 0;
+  }
+  return Math.ceil(totalTeachers * 0.7);
+}
+
+export function quorumStatus(presentCount: number, totalTeachers: number) {
+  const required = requiredQuorum(totalTeachers);
+  return {
+    required,
+    ok: presentCount >= required
+  };
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const teacherSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(2),
+  subjects: z.string().optional()
+});
+
+export const classSchema = z.object({
+  name: z.string().min(2)
+});
+
+export const councilSchema = z.object({
+  classId: z.string().min(1),
+  startsAt: z.string().min(1),
+  location: z.string().optional()
+});
+
+export const assignmentSchema = z.object({
+  classId: z.string().min(1),
+  teacherId: z.string().min(1)
+});
+
+export const attendanceSchema = z.object({
+  councilId: z.string().min(1),
+  status: z.enum(["PRESENT", "ABSENT"])
+});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: { allowedOrigins: ["localhost:3000"] }
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "council-quorum-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:generate": "prisma generate",
+    "prisma:seed": "prisma db seed",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.18.0",
+    "bcryptjs": "^2.4.3",
+    "csv-parse": "^5.5.6",
+    "next": "^14.2.5",
+    "next-auth": "^4.24.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "prisma": "^5.18.0",
+    "postcss": "^8.4.40",
+    "tailwindcss": "^3.4.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  },
+  "prisma": {
+    "seed": "ts-node --transpile-only prisma/seed.ts"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,82 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  ADMIN
+  PROF
+}
+
+enum AttendanceStatus {
+  PENDING
+  PRESENT
+  ABSENT
+}
+
+model User {
+  id           String          @id @default(cuid())
+  email        String          @unique
+  passwordHash String
+  role         Role
+  createdAt    DateTime        @default(now())
+  teacherProfile TeacherProfile?
+  classLinks   ClassTeacher[]  @relation("TeacherClasses")
+  attendances  Attendance[]    @relation("TeacherAttendances")
+}
+
+model TeacherProfile {
+  id        String @id @default(cuid())
+  name      String
+  subjects  String?
+  userId    String @unique
+  user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Class {
+  id          String         @id @default(cuid())
+  name        String         @unique
+  createdAt   DateTime       @default(now())
+  teachers    ClassTeacher[]
+  councils    Council[]
+}
+
+model ClassTeacher {
+  id        String @id @default(cuid())
+  classId   String
+  teacherId String
+  class     Class  @relation(fields: [classId], references: [id], onDelete: Cascade)
+  teacher   User   @relation("TeacherClasses", fields: [teacherId], references: [id], onDelete: Cascade)
+
+  @@unique([classId, teacherId])
+  @@index([teacherId])
+}
+
+model Council {
+  id        String      @id @default(cuid())
+  classId   String
+  startsAt  DateTime
+  location  String?
+  createdAt DateTime    @default(now())
+  class     Class       @relation(fields: [classId], references: [id], onDelete: Cascade)
+  attendances Attendance[]
+
+  @@index([classId, startsAt])
+}
+
+model Attendance {
+  id        String           @id @default(cuid())
+  councilId String
+  teacherId String
+  status    AttendanceStatus @default(PENDING)
+  updatedAt DateTime         @updatedAt
+  council   Council          @relation(fields: [councilId], references: [id], onDelete: Cascade)
+  teacher   User             @relation("TeacherAttendances", fields: [teacherId], references: [id], onDelete: Cascade)
+
+  @@unique([councilId, teacherId])
+  @@index([teacherId])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,112 @@
+import { PrismaClient, AttendanceStatus, Role } from "@prisma/client";
+import { hash } from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const passwordAdmin = await hash("direction", 10);
+  const passwordTeacher = await hash("professeur", 10);
+
+  await prisma.attendance.deleteMany();
+  await prisma.council.deleteMany();
+  await prisma.classTeacher.deleteMany();
+  await prisma.teacherProfile.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.class.deleteMany();
+
+  const admin = await prisma.user.create({
+    data: {
+      email: "direction@gmail.com",
+      passwordHash: passwordAdmin,
+      role: Role.ADMIN,
+      teacherProfile: {
+        create: {
+          name: "Direction"
+        }
+      }
+    }
+  });
+
+  const teachers = await Promise.all(
+    Array.from({ length: 10 }).map((_, index) =>
+      prisma.user.create({
+        data: {
+          email: index === 0 ? "professeur@gmail.com" : `prof${index + 1}@gmail.com`,
+          passwordHash: passwordTeacher,
+          role: Role.PROF,
+          teacherProfile: {
+            create: {
+              name: index === 0 ? "Professeur 1" : `Professeur ${index + 1}`,
+              subjects: index % 2 === 0 ? "Mathématiques" : "Français"
+            }
+          }
+        }
+      })
+    )
+  );
+
+  const classes = await prisma.class.createMany({
+    data: [{ name: "3A" }, { name: "4B" }]
+  });
+
+  const classList = await prisma.class.findMany();
+
+  await prisma.classTeacher.createMany({
+    data: teachers.flatMap((teacher, index) => ({
+      classId: classList[index % classList.length].id,
+      teacherId: teacher.id
+    }))
+  });
+
+  const now = new Date();
+  const councils = await prisma.council.createMany({
+    data: [
+      {
+        classId: classList[0].id,
+        startsAt: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000),
+        location: "Salle 101"
+      },
+      {
+        classId: classList[0].id,
+        startsAt: new Date(now.getTime() + 10 * 24 * 60 * 60 * 1000),
+        location: "Salle 102"
+      },
+      {
+        classId: classList[1].id,
+        startsAt: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000),
+        location: "Salle 201"
+      },
+      {
+        classId: classList[1].id,
+        startsAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+        location: "Salle 202"
+      }
+    ]
+  });
+
+  const councilList = await prisma.council.findMany();
+  const classTeachers = await prisma.classTeacher.findMany();
+
+  await prisma.attendance.createMany({
+    data: councilList.flatMap((council) =>
+      classTeachers
+        .filter((link) => link.classId === council.classId)
+        .map((link, idx) => ({
+          councilId: council.id,
+          teacherId: link.teacherId,
+          status: idx % 3 === 0 ? AttendanceStatus.PRESENT : AttendanceStatus.PENDING
+        }))
+    )
+  });
+
+  console.log(`Seeded with admin ${admin.email} and ${teachers.length} teachers.`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tests/attendance.integration.test.ts
+++ b/tests/attendance.integration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { updateAttendance } from "@/lib/attendance-service";
+import { randomUUID } from "crypto";
+
+const databaseUrl = "file:./tests/test.db";
+
+const prisma = new PrismaClient({
+  datasources: {
+    db: { url: databaseUrl }
+  }
+});
+
+async function setupSchema() {
+  await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS Attendance;`);
+  await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS Council;`);
+  await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS User;`);
+  await prisma.$executeRawUnsafe(`CREATE TABLE User (
+    id TEXT PRIMARY KEY,
+    email TEXT UNIQUE,
+    passwordHash TEXT,
+    role TEXT,
+    createdAt DATETIME
+  );`);
+  await prisma.$executeRawUnsafe(`CREATE TABLE Council (
+    id TEXT PRIMARY KEY,
+    classId TEXT,
+    startsAt DATETIME,
+    location TEXT,
+    createdAt DATETIME
+  );`);
+  await prisma.$executeRawUnsafe(`CREATE TABLE Attendance (
+    id TEXT PRIMARY KEY,
+    councilId TEXT,
+    teacherId TEXT,
+    status TEXT,
+    updatedAt DATETIME
+  );`);
+  await prisma.$executeRawUnsafe(`CREATE UNIQUE INDEX Attendance_councilId_teacherId_key ON Attendance (councilId, teacherId);`);
+}
+
+describe("updateAttendance", () => {
+  beforeAll(async () => {
+    await setupSchema();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("creates attendance for future council", async () => {
+    const teacherId = randomUUID();
+    const councilId = randomUUID();
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO User (id, email, passwordHash, role, createdAt) VALUES (?, ?, ?, ?, ?)`,
+      teacherId,
+      "teacher@example.com",
+      "hash",
+      "PROF",
+      new Date().toISOString()
+    );
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO Council (id, classId, startsAt, location, createdAt) VALUES (?, ?, ?, ?, ?)`,
+      councilId,
+      "class-1",
+      new Date(Date.now() + 86400000).toISOString(),
+      "Salle 1",
+      new Date().toISOString()
+    );
+
+    const attendance = await updateAttendance(prisma, {
+      councilId,
+      teacherId,
+      status: "PRESENT"
+    });
+
+    expect(attendance.status).toBe("PRESENT");
+  });
+});

--- a/tests/quorum.test.ts
+++ b/tests/quorum.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { requiredQuorum, quorumStatus } from "@/lib/quorum";
+
+describe("quorum", () => {
+  it("ceil to 70%", () => {
+    expect(requiredQuorum(10)).toBe(7);
+    expect(requiredQuorum(9)).toBe(7);
+    expect(requiredQuorum(1)).toBe(1);
+  });
+
+  it("flags when quorum is met", () => {
+    expect(quorumStatus(7, 10).ok).toBe(true);
+    expect(quorumStatus(6, 10).ok).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@/app/*": ["./app/*"],
+      "@/lib/*": ["./lib/*"],
+      "@/components/*": ["./components/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,17 @@
+import "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      name?: string | null;
+      email?: string | null;
+      role?: string | null;
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: string | null;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+});


### PR DESCRIPTION
### Motivation
- Ensure the demo credentials work even when the database seed was not run by auto-provisioning known demo accounts during authentication.

### Description
- Update `lib/auth.ts` to detect demo emails in `authorize`, auto-create the corresponding user (hashing the password) and return the session (adds `getDemoAccount` helper). 
- Document the auto-provisioning behavior and the demo credentials in `README.md`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971447d07208322bd29c65511fdea5d)